### PR TITLE
Implement rule validation and reconciliation using WebSocket ping-pong with rule hash

### DIFF
--- a/service/ruledispatcher/ruledispatcher.go
+++ b/service/ruledispatcher/ruledispatcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/tratteria/tconfigd/common"
 	"github.com/tratteria/tconfigd/tratteriacontroller/pkg/apis/tratteria/v1alpha1"
@@ -24,16 +25,32 @@ func (rd *RuleDispatcher) SetClientsRetriever(clientsRetriever websocketserver.C
 }
 
 //nolint:unparam
-func (rd *RuleDispatcher) dispatchRule(ctx context.Context, serviceName string, namespace string, messageType websocketserver.MessageType, rule json.RawMessage) error {
+func (rd *RuleDispatcher) dispatchRule(ctx context.Context, serviceName string, namespace string, messageType websocketserver.MessageType, rule json.RawMessage, versionNumber int64) error {
 	clients := rd.clientsRetriever.GetClientManagers(serviceName, namespace)
 
 	var dispatchErrors []string
 
 	for _, client := range clients {
-		_, err := client.SendRequest(messageType, rule)
+		/*
+		Only propagate rules to clients that don't already have the change. If a client's version number 
+		is equal to or greater than this particular change's version number, the client already 
+		incorporates this change.
+		
+		Clients can incorporate changes without being explicitly pushed through the reconciliation process.
+		
+		Reconciliation serves as a backup process for propagating changes and correcting any out-of-order 
+		or missed propagations.
+		
+		If a client's rule hash is found to be different, the client replaces its complete rule set with
+		the latest rule set and adopts the version number associated with the rules it just received.
+		*/
+		
+		if atomic.LoadInt64(&client.RuleVersionNumber) < versionNumber {
+			_, err := client.SendRequest(messageType, rule)
 
-		if err != nil {
-			dispatchErrors = append(dispatchErrors, err.Error())
+			if err != nil {
+				dispatchErrors = append(dispatchErrors, err.Error())
+			}
 		}
 	}
 
@@ -44,13 +61,13 @@ func (rd *RuleDispatcher) dispatchRule(ctx context.Context, serviceName string, 
 	return nil
 }
 
-func (rd *RuleDispatcher) DispatchTraTVerificationRule(ctx context.Context, serviceName string, namespace string, verificationEndpointRule *v1alpha1.TraTVerificationRule) error {
+func (rd *RuleDispatcher) DispatchTraTVerificationRule(ctx context.Context, serviceName string, namespace string, verificationEndpointRule *v1alpha1.TraTVerificationRule, versionNumber int64) error {
 	jsonData, err := json.Marshal(verificationEndpointRule)
 	if err != nil {
 		return fmt.Errorf("error marshaling verification trat rule: %w", err)
 	}
 
-	err = rd.dispatchRule(ctx, serviceName, namespace, websocketserver.MessageTypeTraTVerificationRuleUpsertRequest, jsonData)
+	err = rd.dispatchRule(ctx, serviceName, namespace, websocketserver.MessageTypeTraTVerificationRuleUpsertRequest, jsonData, versionNumber)
 	if err != nil {
 		return fmt.Errorf("error dispatching verification trat rule to %s service: %w", serviceName, err)
 	}
@@ -58,7 +75,7 @@ func (rd *RuleDispatcher) DispatchTraTVerificationRule(ctx context.Context, serv
 	return nil
 }
 
-func (rd *RuleDispatcher) DispatchTratteriaConfigVerificationRule(ctx context.Context, namespace string, verificationTokenRule *v1alpha1.TratteriaConfigVerificationRule) error {
+func (rd *RuleDispatcher) DispatchTratteriaConfigVerificationRule(ctx context.Context, namespace string, verificationTokenRule *v1alpha1.TratteriaConfigVerificationRule, versionNumber int64) error {
 	jsonData, err := json.Marshal(verificationTokenRule)
 	if err != nil {
 		return fmt.Errorf("error marshaling verification tratteria config rule: %w", err)
@@ -67,7 +84,7 @@ func (rd *RuleDispatcher) DispatchTratteriaConfigVerificationRule(ctx context.Co
 	var dispatchErrors []string
 
 	for _, serviceName := range rd.clientsRetriever.GetTratteriaAgentServices(namespace) {
-		err = rd.dispatchRule(ctx, serviceName, namespace, websocketserver.MessageTypeTratteriaConfigVerificationRuleUpsertRequest, jsonData)
+		err = rd.dispatchRule(ctx, serviceName, namespace, websocketserver.MessageTypeTratteriaConfigVerificationRuleUpsertRequest, jsonData, versionNumber)
 		if err != nil {
 			dispatchErrors = append(dispatchErrors, fmt.Sprintf("error dispatching verification token rule to %s service: %v", serviceName, err))
 		}
@@ -80,13 +97,13 @@ func (rd *RuleDispatcher) DispatchTratteriaConfigVerificationRule(ctx context.Co
 	return nil
 }
 
-func (rd *RuleDispatcher) DispatchTraTGenerationRule(ctx context.Context, namespace string, generationEndpointRule *v1alpha1.TraTGenerationRule) error {
+func (rd *RuleDispatcher) DispatchTraTGenerationRule(ctx context.Context, namespace string, generationEndpointRule *v1alpha1.TraTGenerationRule, verisionNumber int64) error {
 	jsonData, err := json.Marshal(generationEndpointRule)
 	if err != nil {
 		return fmt.Errorf("error marshaling generation trat rule: %w", err)
 	}
 
-	err = rd.dispatchRule(ctx, common.TRATTERIA_SERVICE_NAME, namespace, websocketserver.MessageTypeTraTGenerationRuleUpsertRequest, jsonData)
+	err = rd.dispatchRule(ctx, common.TRATTERIA_SERVICE_NAME, namespace, websocketserver.MessageTypeTraTGenerationRuleUpsertRequest, jsonData, verisionNumber)
 	if err != nil {
 		return fmt.Errorf("error dispatching generation trat rule to tratteria: %w", err)
 	}
@@ -94,13 +111,13 @@ func (rd *RuleDispatcher) DispatchTraTGenerationRule(ctx context.Context, namesp
 	return nil
 }
 
-func (rd *RuleDispatcher) DispatchTratteriaConfigGenerationRule(ctx context.Context, namespace string, generationTokenRule *v1alpha1.TratteriaConfigGenerationRule) error {
+func (rd *RuleDispatcher) DispatchTratteriaConfigGenerationRule(ctx context.Context, namespace string, generationTokenRule *v1alpha1.TratteriaConfigGenerationRule, versionNumber int64) error {
 	jsonData, err := json.Marshal(generationTokenRule)
 	if err != nil {
 		return fmt.Errorf("error marshaling generation tratteria config rule: %w", err)
 	}
 
-	err = rd.dispatchRule(ctx, common.TRATTERIA_SERVICE_NAME, namespace, websocketserver.MessageTypeTratteriaConfigGenerationRuleUpsertRequest, jsonData)
+	err = rd.dispatchRule(ctx, common.TRATTERIA_SERVICE_NAME, namespace, websocketserver.MessageTypeTratteriaConfigGenerationRuleUpsertRequest, jsonData, versionNumber)
 	if err != nil {
 		return fmt.Errorf("error dispatching generation tratteria config rule to tratteria: %w", err)
 	}

--- a/service/ruledispatcher/ruledispatcher.go
+++ b/service/ruledispatcher/ruledispatcher.go
@@ -29,22 +29,20 @@ func (rd *RuleDispatcher) dispatchRule(ctx context.Context, serviceName string, 
 	clients := rd.clientsRetriever.GetClientManagers(serviceName, namespace)
 
 	var dispatchErrors []string
-
-	for _, client := range clients {
-		/*
-		Only propagate rules to clients that don't already have the change. If a client's version number 
-		is equal to or greater than this particular change's version number, the client already 
+	/*
+		Only propagate rules to clients that don't already have the change. If a client's version number
+		is equal to or greater than this particular change's version number, the client already
 		incorporates this change.
-		
+
 		Clients can incorporate changes without being explicitly pushed through the reconciliation process.
-		
-		Reconciliation serves as a backup process for propagating changes and correcting any out-of-order 
+
+		Reconciliation serves as a backup process for propagating changes and correcting any out-of-order
 		or missed propagations.
-		
+
 		If a client's rule hash is found to be different, the client replaces its complete rule set with
 		the latest rule set and adopts the version number associated with the rules it just received.
-		*/
-		
+	*/
+	for _, client := range clients {
 		if atomic.LoadInt64(&client.RuleVersionNumber) < versionNumber {
 			_, err := client.SendRequest(messageType, rule)
 

--- a/service/tratteriacontroller/controller/controller.go
+++ b/service/tratteriacontroller/controller/controller.go
@@ -263,10 +263,6 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger := klog.FromContext(ctx)
-
-	logger.V(4).Info("Processing", "resourceType", resourceType, "key", objectKey, "version", versionNumber)
-
 	switch resourceType {
 	case TraTKind:
 		return c.handleTraT(ctx, objectKey, int64(versionNumber))

--- a/service/tratteriacontroller/controller/tratconfigcontroller.go
+++ b/service/tratteriacontroller/controller/tratconfigcontroller.go
@@ -15,7 +15,7 @@ import (
 	tratteria1alpha1 "github.com/tratteria/tconfigd/tratteriacontroller/pkg/apis/tratteria/v1alpha1"
 )
 
-func (c *Controller) handleTratteriaConfig(ctx context.Context, key string) error {
+func (c *Controller) handleTratteriaConfig(ctx context.Context, key string, versionNumber int64) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 
 	if err != nil {
@@ -48,7 +48,7 @@ func (c *Controller) handleTratteriaConfig(ctx context.Context, key string) erro
 		return messagedErr
 	}
 
-	err = c.ruleDispatcher.DispatchTratteriaConfigVerificationRule(ctx, namespace, verificationTokenRule)
+	err = c.ruleDispatcher.DispatchTratteriaConfigVerificationRule(ctx, namespace, verificationTokenRule, versionNumber)
 	if err != nil {
 		messagedErr := fmt.Errorf("error dispatching %s tratteria config verification token rule: %w", name, err)
 
@@ -76,7 +76,7 @@ func (c *Controller) handleTratteriaConfig(ctx context.Context, key string) erro
 		return messagedErr
 	}
 
-	err = c.ruleDispatcher.DispatchTratteriaConfigGenerationRule(ctx, namespace, generationTokenRule)
+	err = c.ruleDispatcher.DispatchTratteriaConfigGenerationRule(ctx, namespace, generationTokenRule, versionNumber)
 	if err != nil {
 		messagedErr := fmt.Errorf("error dispatching %s tratteria config generation token rule: %w", name, err)
 
@@ -138,12 +138,10 @@ func (c *Controller) GetActiveTratteriaConfigVerificationRule(namespace string) 
 	}
 
 	for _, config := range tratteriaConfigs {
-		if config.Status.Status == "DONE" {
-			verificationTokenRule, err := config.GetTratteriaConfigVerificationRule()
-			if err != nil {
-				return nil, err
-			}
-
+		verificationTokenRule, err := config.GetTratteriaConfigVerificationRule()
+		if err != nil {
+			return nil, err
+		} else {
 			return verificationTokenRule, nil
 		}
 	}
@@ -160,13 +158,12 @@ func (c *Controller) GetActiveGenerationTokenRule(namespace string) (*tratteria1
 	}
 
 	for _, config := range tratteriaConfigs {
-		if config.Status.Status == "DONE" {
-			generationTokenRule, err := config.GetTratteriaConfigGenerationRule()
-			if err != nil {
-				return nil, err
-			}
-
+		generationTokenRule, err := config.GetTratteriaConfigGenerationRule()
+		if err != nil {
+			return nil, err
+		} else {
 			return generationTokenRule, nil
+
 		}
 	}
 

--- a/service/tratteriacontroller/ruleretriever/ruleretriever.go
+++ b/service/tratteriacontroller/ruleretriever/ruleretriever.go
@@ -5,6 +5,8 @@ import (
 )
 
 type RuleRetriever interface {
-	GetActiveVerificationRules(serviceName string, namespace string) (*tratteria1alpha1.VerificationRules, error)
-	GetActiveGenerationRules(namespace string) (*tratteria1alpha1.GenerationRules, error)
+	GetActiveVerificationRules(serviceName string, namespace string) (*tratteria1alpha1.VerificationRules, int64, error)
+	GetActiveVerificationRulesHash(serviceName string, namespace string) (string, int64, error)
+	GetActiveGenerationRules(namespace string) (*tratteria1alpha1.GenerationRules, int64, error)
+	GetActiveGenerationRulesHash(namespace string) (string, int64, error)
 }

--- a/service/utils/utils.go
+++ b/service/utils/utils.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func CanonicalizeJSON(data interface{}) (string, error) {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		var pairs []string
+
+		keys := make([]string, 0, len(v))
+
+		for k := range v {
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			val, err := CanonicalizeJSON(v[k])
+			if err != nil {
+				return "", err
+			}
+
+			pairs = append(pairs, fmt.Sprintf("%q:%s", k, val))
+		}
+
+		return "{" + strings.Join(pairs, ",") + "}", nil
+	case []interface{}:
+		var items []string
+
+		for _, item := range v {
+			val, err := CanonicalizeJSON(item)
+			if err != nil {
+				return "", err
+			}
+
+			items = append(items, val)
+		}
+
+		return "[" + strings.Join(items, ",") + "]", nil
+	default:
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+
+		return string(jsonBytes), nil
+	}
+}

--- a/service/websocketserver/clientmanager.go
+++ b/service/websocketserver/clientmanager.go
@@ -1,5 +1,6 @@
 /**
-Rule Propagation Approach:
+Rule Propagation Approach(Here, rule means general rules for constructing and validating TraTs.
+It is the combination of all Tratteria resources i.e TraTs, TratteriaConfig, and TraTExclusion):
 
 When tconfigd starts (or restarts, or when the leader changes if multiple replicas are present), it initializes an
 in-memory global rule version number starting at zero. Similarly, for each WebSocket client (i.e., Tratteria Service

--- a/service/websocketserver/clientmanager.go
+++ b/service/websocketserver/clientmanager.go
@@ -12,7 +12,7 @@ updates its cache, and invokes the respective handler. Each handler performs the
 
 1. Increments the global rule version number by 1 and assigns this version number to the operation.
 2. Loops through the clients that need to receive this change.
-3. If the client's rule version number is less than the operation's version number, pushes the change to the client.
+3. If the client's rule version number is less than the operation's version number, push the change to the client.
 4. If all pushes succeed, marks the operation as done. If any push fails, marks the operation as pending and
    requeues it to the work queue.
 

--- a/service/websocketserver/setup.go
+++ b/service/websocketserver/setup.go
@@ -162,7 +162,9 @@ func (wss *WebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Reque
 
 	// The retrieved rules are guaranteed to incorporate changes up to and including this version number
 	var activeRuleVersionNumber int64
+
 	var activeGenerationRules *tratteria1alpha1.GenerationRules
+
 	var activeVerificationRules *tratteria1alpha1.VerificationRules
 
 	initialRulesPayload := &AllActiveRulesPayload{}


### PR DESCRIPTION
Rule Propagation Approach(Here, rule means general rules for constructing and validating TraTs. It is the combination of all Tratteria resources i.e TraTs, TratteriaConfig, and TraTExclusion):

When tconfigd starts (or restarts, or when the leader changes if multiple replicas are present), it initializes an
in-memory global rule version number starting at zero. Similarly, for each WebSocket client (i.e., Tratteria Service
and Tratteria Agents), it assigns a client rule version number also starting at zero. These rule version numbers
represent the state of the rules, with higher numbers indicating more recent states. These version numbers are
maintained only in tconfigd's memory and are not relevant to other components.

When an Add, Update, or Delete operation of a Custom Resource (CR) occurs, tconfigd's informer is notified,
updates its cache, and invokes the respective handler. Each handler performs the following:

1. Increments the global rule version number by 1 and assigns this version number to the operation.
2. Loops through the clients that need to receive this change.
3. If the client's rule version number is less than the operation's version number, push the change to the client.
4. If all pushes succeed, marks the operation as done. If any push fails, marks the operation as pending and
   requeues it to the work queue.

In addition to individual change propagation, regular rule validation and reconciliation are performed.
Each client performs the following:

1. Every 60 seconds (configurable through tconfigd static configuration), the client sends a WebSocket ping to the
   WebSocket server with its rule hash.
2. The WebSocket server replies with a WebSocket pong.
3. The WebSocket server compares the received hash with the latest hash. If they are the same, it updates the
   client's version number to the latest hash rule version number.
4. If the received hash and latest hash are different, it performs a reconciliation request to the client and
   updates the client version number to the reconciled rules version number.

The regular rule validation and reconciliation serve the following purposes:

1. It acts as a backup to the individual change propagation. If certain individual change propagations fail,
   they will be propagated through the reconciliation process.
2. If any rule propagation fails or if rules are propagated in an incorrect order resulting in inconsistent rules
   on the client side, the reconciliation process will correct the client's rules.

The reconciliation process ensures eventual consistency of the rules in the system.