### PR TITLE
Allow http method overriding in TraT call chain services

### DIFF
--- a/installation/resources/crds/trat-crd.yaml
+++ b/installation/resources/crds/trat-crd.yaml
@@ -47,6 +47,8 @@ spec:
                         type: string
                       endpoint:
                         type: string
+                      method:
+                        type: string
                       azdMapping:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true

--- a/service/tratteriacontroller/pkg/apis/tratteria/v1alpha1/types.go
+++ b/service/tratteriacontroller/pkg/apis/tratteria/v1alpha1/types.go
@@ -33,6 +33,7 @@ type TraTSpec struct {
 type ServiceSpec struct {
 	Name       string     `json:"name"`
 	Endpoint   string     `json:"endpoint,omitempty"`
+	Method     string     `json:"method,omitempty"`
 	AzdMapping AzdMapping `json:"azdMapping,omitempty"`
 }
 
@@ -82,10 +83,15 @@ func (traT *TraT) GetTraTVerificationRules() (map[string]*TraTVerificationRule, 
 
 	for _, serviceSpec := range traT.Spec.Services {
 		endpoint := traT.Spec.Endpoint
+		method := traT.Spec.Method
 		azdMapping := traT.Spec.AzdMapping
 
 		if serviceSpec.Endpoint != "" {
 			endpoint = serviceSpec.Endpoint
+		}
+
+		if serviceSpec.Method != "" {
+			method = serviceSpec.Method
 		}
 
 		if serviceSpec.AzdMapping != nil {
@@ -95,7 +101,7 @@ func (traT *TraT) GetTraTVerificationRules() (map[string]*TraTVerificationRule, 
 		verificationRules[serviceSpec.Name] = &TraTVerificationRule{
 			TraTName:   traT.Name,
 			Endpoint:   endpoint,
-			Method:     traT.Spec.Method,
+			Method:     method,
 			Purp:       traT.Spec.Purp,
 			AzdMapping: azdMapping,
 		}


### PR DESCRIPTION
This PR fixes the bug of services not being able to override HTTP method in TraTs call chain specification section.