### PR TITLE
Extract the service name from a SPIFFE path

### DIFF
--- a/service/websocketserver/setup.go
+++ b/service/websocketserver/setup.go
@@ -110,7 +110,8 @@ func (wss *WebSocketServer) handleWebSocket(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	serviceName := strings.TrimPrefix(spiffeID.Path(), "/")
+	pathParts := strings.Split(spiffeID.Path(), "/")
+	serviceName := pathParts[len(pathParts)-1]
 
 	namespace := r.URL.Query().Get("namespace")
 	if namespace == "" {


### PR DESCRIPTION
A SPIFFE ID has a path that can be used to encode keys and values - eg a namespace (`ns`) and service account (`sa`):

`spiffe://trust.domain/ns/foo/sa/bar`

This update finds the service name using the service account `sa` component of the path in the ID. This was required in order to use `tconfigd` in an environment with SPIRE on Kubenetes, using the standard SPIFFE ID format.

The alternative to this would be to keep the existing implementation and update the service name to include the full path. This is currently hardcoded (https://github.com/tokenetes/tconfigd/blob/main/service/common/common.go#L4) so we'd need a way to configure this.
